### PR TITLE
Fix signup 500 error

### DIFF
--- a/backend/store/serializers.py
+++ b/backend/store/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from .models import Product, Customer, UtangEntry, Payment
 from django.contrib.auth.models import User
+from django.db import IntegrityError
 
 
 class ProductSerializer(serializers.ModelSerializer):
@@ -42,5 +43,10 @@ class RegisterSerializer(serializers.ModelSerializer):
         extra_kwargs = {'password': {'write_only': True}}
 
     def create(self, validated_data):
-        user = User.objects.create_user(**validated_data)
+        try:
+            user = User.objects.create_user(**validated_data)
+        except IntegrityError:
+            raise serializers.ValidationError({
+                'username': 'A user with that username already exists.'
+            })
         return user


### PR DESCRIPTION
## Summary
- handle duplicate username errors when registering a new account

## Testing
- `python -m py_compile store/serializers.py`
- `python -m py_compile store/views.py store/models.py store/urls.py sari_store/settings.py`
- `npm run build` *(fails: vite permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684f665b1ad8832496b5f7df9ce62e4c