### PR TITLE
Allow configuring API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,13 @@ npm install
 npm run dev
 ```
 
+When serving the production build outside of the Vite development server,
+set the `VITE_API_URL` environment variable so the frontend knows where your
+Django backend lives:
+
+```bash
+export VITE_API_URL=http://localhost:8000
+npm run build
+```
+
 This is a minimal example intended for educational purposes. Use it as a starting point for a more complete application.

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,6 +1,12 @@
 import axios from 'axios'
 
-const api = axios.create()
+// Allow overriding the API base URL so that production builds can
+// communicate with the Django backend even when served from a different
+// domain or port. During local development the Vite proxy handles API
+// requests, so we keep the base URL empty in that case.
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || ''
+})
 
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem('token')


### PR DESCRIPTION
## Summary
- enable configuring axios base URL for production builds
- document `VITE_API_URL` variable in README

## Testing
- `python manage.py test store.tests.test_integration` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684f7e512d4c8324a0fc376cb39ed6cb