### PR TITLE
Allow configuring API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+DB_ENGINE=django.db.backends.mysql
+DB_NAME=sari_store_db
+DB_USER=sari_admin
+DB_PASSWORD=hotmariaclara24
+DB_HOST=localhost
+DB_PORT=3306

--- a/README.md
+++ b/README.md
@@ -19,8 +19,15 @@ pip install -r requirements.txt
 ```
 
 The backend reads its MySQL credentials from environment variables so it can
-connect to a live database or fall back to SQLite for tests. Set the following
-variables before running migrations:
+connect to a live database or fall back to SQLite for tests. Create a `.env`
+file using the provided example and adjust the credentials before running
+migrations:
+
+```bash
+cp .env.example .env
+```
+
+Then edit `.env` with your MySQL settings. Example contents:
 
 ```
 export DB_ENGINE=django.db.backends.mysql
@@ -54,6 +61,15 @@ Install dependencies and start the dev server:
 cd frontend
 npm install
 npm run dev
+```
+
+When serving the production build outside of the Vite development server,
+set the `VITE_API_URL` environment variable so the frontend knows where your
+Django backend lives:
+
+```bash
+export VITE_API_URL=http://localhost:8000
+npm run build
 ```
 
 This is a minimal example intended for educational purposes. Use it as a starting point for a more complete application.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ django>=4.2
 mysqlclient
 djangorestframework
 djangorestframework-simplejwt
+python-dotenv

--- a/backend/sari_store/settings.py
+++ b/backend/sari_store/settings.py
@@ -1,5 +1,8 @@
 from pathlib import Path
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,6 +1,12 @@
 import axios from 'axios'
 
-const api = axios.create()
+// Allow overriding the API base URL so that production builds can
+// communicate with the Django backend even when served from a different
+// domain or port. During local development the Vite proxy handles API
+// requests, so we keep the base URL empty in that case.
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || ''
+})
 
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem('token')


### PR DESCRIPTION
## Summary
- enable configuring axios base URL for production builds
- document `VITE_API_URL` variable in README
- load environment variables for Django from `.env`

## Testing
- `python manage.py test store.tests.test_integration` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684f7e512d4c8324a0fc376cb39ed6cb