### PR TITLE
Fix default DB settings to use sqlite

### DIFF
--- a/backend/sari_store/settings.py
+++ b/backend/sari_store/settings.py
@@ -61,7 +61,9 @@ REST_FRAMEWORK = {
     ),
 }
 
-DB_ENGINE = os.getenv("DB_ENGINE", "django.db.backends.mysql")
+# Use SQLite by default for easier local setup. A different engine can be
+# supplied via environment variables when needed.
+DB_ENGINE = os.getenv("DB_ENGINE", "django.db.backends.sqlite3")
 DB_NAME = os.getenv(
     "DB_NAME",
     str(BASE_DIR / "db.sqlite3") if DB_ENGINE == "django.db.backends.sqlite3" else "sari_store_db",


### PR DESCRIPTION
## Summary
- default Django database engine to sqlite to prevent server errors when no database env is configured

## Testing
- `python -m py_compile backend/sari_store/settings.py`


------
https://chatgpt.com/codex/tasks/task_e_684f82e3b4d88324b02c383250977dd9